### PR TITLE
Allow Keywords as method arguments.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -367,7 +367,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
             .addModifiers(Modifier.PUBLIC)
 
         fieldDefinition.inputValueDefinitions.forEach { input ->
-            methodBuilder.addParameter(ParameterSpec.builder(typeUtils.findReturnType(input.type), input.name).build())
+            methodBuilder.addParameter(ParameterSpec.builder(typeUtils.findReturnType(input.type), ReservedKeywordSanitizer.sanitize(input.name)).build())
         }
         return javaType.addMethod(methodBuilder.build())
     }


### PR DESCRIPTION
Was seeing an issue running the generateJava task when trying to generate from the following spec component:

https://docs.github.com/en/graphql/overview/public-schema
```
  """
  Software Vulnerabilities documented by GitHub Security Advisories
  """
  securityVulnerabilities(
    """
    Returns the elements in the list that come after the specified cursor.
    """
    after: String

    """
    Returns the elements in the list that come before the specified cursor.
    """
    before: String

    """
    A list of advisory classifications to filter vulnerabilities by.
    """
    classifications: [SecurityAdvisoryClassification!]

    """
    An ecosystem to filter vulnerabilities by.
    """
    ecosystem: SecurityAdvisoryEcosystem

    """
    Returns the first _n_ elements from the list.
    """
    first: Int

    """
    Returns the last _n_ elements from the list.
    """
    last: Int

    """
    Ordering options for the returned topics.
    """
    orderBy: SecurityVulnerabilityOrder = {field: UPDATED_AT, direction: DESC}

    """
    A package name to filter vulnerabilities by.
    """
    package: String

    """
    A list of severities to filter vulnerabilities by.
    """
    severities: [SecurityAdvisorySeverity!]
  ): SecurityVulnerabilityConnection!
```

With the following options:
```
tasks.withType<com.netflix.graphql.dgs.codegen.gradle.GenerateJavaTask> {
    generateClientv2 = true
    packageName = "com.brainera.web.integrations.git.github.graphql"
    typeMapping =
        mutableMapOf(
            "URI" to "java.net.URI",
            "GitObjectID" to "java.lang.String",
            "PreciseDateTime" to "java.lang.String",
            "HTML" to "java.lang.String",
            "X509Certificate" to "java.lang.String",
            "GitTimestamp" to "java.lang.String",
            "Base64String" to "java.lang.String",
            "GitRefname" to "java.lang.String",
            "GitSSHRemote" to "kotlin.String"
        )
}
```

Got the following stack trace:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':github-graphql-client:generateJava'.
> not a valid name: package

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':github-graphql-client:generateJava'.
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:142)
        at org.gradle.internal.Try$Failure.ifSuccessfulOrElse(Try.java:282)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:140)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:128)
        at org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter.execute(CleanupStaleOutputsExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
        at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:56)
        at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
        at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:69)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:327)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:314)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:307)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:293)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:420)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:342)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
Caused by: java.lang.IllegalArgumentException: not a valid name: package
        at com.squareup.javapoet.Util.checkArgument(Util.java:53)
        at com.squareup.javapoet.ParameterSpec.builder(ParameterSpec.java:117)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFieldSelectionMethodWithArguments(ClientApiGenerator.kt:365)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:569)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createConcreteTypes(ClientApiGenerator.kt:420)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:633)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createUnionTypes(ClientApiGenerator.kt:431)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:634)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createUnionTypes(ClientApiGenerator.kt:431)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:634)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createUnionTypes(ClientApiGenerator.kt:431)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:634)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createConcreteTypes(ClientApiGenerator.kt:420)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:633)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createConcreteTypes(ClientApiGenerator.kt:420)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:633)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createUnionTypes(ClientApiGenerator.kt:431)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:634)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createUnionTypes(ClientApiGenerator.kt:431)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:634)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createUnionTypes(ClientApiGenerator.kt:431)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:634)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createFragment(ClientApiGenerator.kt:463)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.addFragmentProjectionMethod(ClientApiGenerator.kt:459)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createUnionTypes(ClientApiGenerator.kt:431)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:634)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjectionType(ClientApiGenerator.kt:574)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createSubProjection(ClientApiGenerator.kt:506)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.createRootProjection(ClientApiGenerator.kt:297)
        at com.netflix.graphql.dgs.codegen.generators.java.ClientApiGenerator.generate(ClientApiGenerator.kt:40)
        at com.netflix.graphql.dgs.codegen.CodeGen$generateJavaClientApi$3.invoke(CodeGen.kt:237)
        at com.netflix.graphql.dgs.codegen.CodeGen$generateJavaClientApi$3.invoke(CodeGen.kt:236)
        at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
        at com.netflix.graphql.dgs.codegen.CodeGen.generateJavaClientApi(CodeGen.kt:834)
        at com.netflix.graphql.dgs.codegen.CodeGen.generateKotlin(CodeGen.kt:369)
        at com.netflix.graphql.dgs.codegen.CodeGen.generate(CodeGen.kt:73)
        at com.netflix.graphql.dgs.codegen.gradle.GenerateJavaTask.generate(GenerateJavaTask.kt:221)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:58)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:51)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:29)
        at org.gradle.api.internal.tasks.execution.TaskExecution$3.run(TaskExecution.java:236)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:68)
        at org.gradle.api.internal.tasks.execution.TaskExecution.executeAction(TaskExecution.java:221)
        at org.gradle.api.internal.tasks.execution.TaskExecution.executeActions(TaskExecution.java:204)
        at org.gradle.api.internal.tasks.execution.TaskExecution.executeWithPreviousOutputFiles(TaskExecution.java:187)
        at org.gradle.api.internal.tasks.execution.TaskExecution.execute(TaskExecution.java:165)
        at org.gradle.internal.execution.steps.ExecuteStep.executeInternal(ExecuteStep.java:89)
        at org.gradle.internal.execution.steps.ExecuteStep.access$000(ExecuteStep.java:40)
        at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:53)
        at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:50)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
        at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:50)
        at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:40)
        at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:68)
        at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:38)
        at org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:41)
        at org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:74)
        at org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:55)
        at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:51)
        at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:29)
        at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.executeDelegateBroadcastingChanges(CaptureStateAfterExecutionStep.java:124)
        at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:80)
        at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:58)
        at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:48)
        at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:36)
        at org.gradle.internal.execution.steps.BuildCacheStep.executeWithoutCache(BuildCacheStep.java:181)
        at org.gradle.internal.execution.steps.BuildCacheStep.lambda$execute$1(BuildCacheStep.java:71)
        at org.gradle.internal.Either$Right.fold(Either.java:175)
        at org.gradle.internal.execution.caching.CachingState.fold(CachingState.java:59)
        at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:69)
        at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:47)
        at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:36)
        at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:25)
        at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:36)
        at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:22)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:110)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$2(SkipUpToDateStep.java:56)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:56)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:38)
        at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:73)
        at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:44)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:37)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:27)
        at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:89)
        at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:50)
        at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:114)
        at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:57)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:76)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:50)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.executeWithNoEmptySources(SkipEmptyWorkStep.java:254)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:91)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:56)
        at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:32)
        at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:21)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
        at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:43)
        at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:31)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.lambda$execute$0(AssignWorkspaceStep.java:40)
        at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:281)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:40)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:30)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:37)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:27)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:44)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:33)
        at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:76)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:139)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:128)
        at org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter.execute(CleanupStaleOutputsExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
        at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:56)
        at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
        at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:69)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:327)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:314)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:307)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:293)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:420)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:342)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
```

Looked like the issue was creating methods with provided key words.